### PR TITLE
18: Adding Superuser endpoint to get company

### DIFF
--- a/src/main/java/com/rrsgroup/waitque/service/CompanyService.java
+++ b/src/main/java/com/rrsgroup/waitque/service/CompanyService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class CompanyService {
     private final CompanyRepository repository;
@@ -29,5 +31,9 @@ public class CompanyService {
                 limit,
                 sortDir == SortDirection.ASC ? Sort.by(sortField).ascending() : Sort.by(sortField).descending());
         return repository.findAll(pageable);
+    }
+
+    public Optional<Company> getCompany(Long companyId) {
+        return repository.findById(companyId);
     }
 }

--- a/src/main/java/com/rrsgroup/waitque/web/CompanyController.java
+++ b/src/main/java/com/rrsgroup/waitque/web/CompanyController.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Optional;
+
 @RestController
 public class CompanyController {
     private final CompanyService companyService;
@@ -46,5 +48,16 @@ public class CompanyController {
         Page<Company> pageOfCompanies = companyService.getListOfCompanies(limit, page, sortField, sortDir);
 
         return mapper.map(pageOfCompanies);
+    }
+
+    @GetMapping("/api/internal/companies/{companyId}")
+    public CompanyDto getCompany(@PathVariable(name = "companyId") Long companyId) {
+        Optional<Company> company = companyService.getCompany(companyId);
+
+        if(company.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Company not found with that ID");
+        }
+
+        return mapper.map(company.get());
     }
 }

--- a/src/test/groovy/com/rrsgroup/waitque/service/CompanyServiceSpec.groovy
+++ b/src/test/groovy/com/rrsgroup/waitque/service/CompanyServiceSpec.groovy
@@ -5,6 +5,7 @@ import com.rrsgroup.waitque.entity.Address
 import com.rrsgroup.waitque.entity.Company
 import com.rrsgroup.waitque.entity.PhoneNumber
 import com.rrsgroup.waitque.repository.CompanyRepository
+import com.rrsgroup.waitque.util.MockGenerator
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import spock.lang.Specification
@@ -12,6 +13,7 @@ import spock.lang.Specification
 class CompanyServiceSpec extends Specification {
     def repository = Mock(CompanyRepository.class)
     def companyService = new CompanyService(repository)
+    def mockGenerator = new MockGenerator()
 
     def "createCompany saves the company via the repository and returns saved company"() {
         given:
@@ -68,5 +70,20 @@ class CompanyServiceSpec extends Specification {
         sortDir            | limit | page | sortField | pageable                                                     | description
         SortDirection.ASC  | 10    | 0    | "id"      | PageRequest.of(page, limit, Sort.by(sortField).ascending())  | "ascending"
         SortDirection.DESC | 10    | 0    | "id"      | PageRequest.of(page, limit, Sort.by(sortField).descending()) | "descending"
+    }
+
+    def "getCompany finds specific company"() {
+        given:
+        def company = mockGenerator.getCompanyMock()
+        def companyId = company.getId()
+
+        when:
+        def result = companyService.getCompany(companyId)
+
+        then:
+        1 * repository.findById(companyId) >> Optional.of(company)
+        0 * _
+        result.isPresent()
+        result.get().id == companyId
     }
 }

--- a/src/test/groovy/com/rrsgroup/waitque/web/CompanyControllerSpec.groovy
+++ b/src/test/groovy/com/rrsgroup/waitque/web/CompanyControllerSpec.groovy
@@ -86,6 +86,36 @@ class CompanyControllerSpec extends Specification {
         result.getCompanies().get(0).getLogoUrl() == company.getLogoUrl()
     }
 
+    def "getCompany returns company for a valid companyId"() {
+        given:
+        def company = mockGenerator.getCompanyMock()
+        def companyId = company.getId()
+
+        when:
+        def result = controller.getCompany(companyId)
+
+        then:
+        1 * companyService.getCompany(companyId) >> Optional.of(company)
+        0 * _
+        result != null
+        result.id() == companyId
+    }
+
+    def "getCompany returns a 404 for a companyId that does not exist"() {
+        given:
+        def companyId = -1
+
+        when:
+        def result = controller.getCompany(companyId)
+
+        then:
+        1 * companyService.getCompany(companyId) >> Optional.empty()
+        0 * _
+        def e = thrown(ResponseStatusException.class)
+        e.getStatusCode() == HttpStatus.NOT_FOUND
+    }
+
+
     private static CompanyDto buildCompanyDto (Long companyId, String name) {
         def logoUrl = "logoUrl.com"
         def landingPrompt = "What do you want to do?"


### PR DESCRIPTION
Added Superuser endpoint `GET /api/internal/companies/4` that returns the following:
```
{
    "id": 4,
    "name": "Test Company",
    "address": {
        "id": 11,
        "address1": "123 Main St",
        "address2": null,
        "city": "Marietta",
        "state": "Georgia",
        "zipcode": "30068",
        "country": null
    },
    "phoneNumber": {
        "id": 11,
        "countryCode": 1,
        "phoneNumber": 1231231234
    },
    "logoUrl": "logoUrl.com",
    "landingPrompt": "What do you want to do?",
    "textColor": "#FFFFFF",
    "backgroundColor": "#000000",
    "primaryButtonColor": "#AAAAAA",
    "secondaryButtonColor": "#BBBBBB",
    "warningButtonColor": "#CCCCCC",
    "dangerButtonColor": "#DDDDDD"
}
```

And a non-existent company ID `GET /api/internal/companies/-1` that returns the following:
```
{
    "timestamp": "2025-08-26T03:35:12.229+00:00",
    "status": 404,
    "error": "Not Found",
    "path": "/api/internal/companies/-1"
}
```