### PR TITLE
36: Adding endpoint to create Lead Flows

### DIFF
--- a/common/src/main/java/com/rrsgroup/common/domain/JwtClaimKey.java
+++ b/common/src/main/java/com/rrsgroup/common/domain/JwtClaimKey.java
@@ -6,7 +6,8 @@ public enum JwtClaimKey {
     LAST_NAME("family_name"),
     EMAIL("email"),
     USERNAME("preferred_username"),
-    COMPANY_ID("company_id");
+    COMPANY_ID("company_id"),
+    USER_ID("sub");
 
     private final String claimKey;
 

--- a/common/src/main/java/com/rrsgroup/common/dto/AdminUserDto.java
+++ b/common/src/main/java/com/rrsgroup/common/dto/AdminUserDto.java
@@ -9,8 +9,8 @@ import lombok.Data;
 public class AdminUserDto extends UserDto {
     private Long companyId;
 
-    public AdminUserDto(String firstName, String lastName, String email, String username, UserRole role, Long companyId) {
-        super(firstName, lastName, email, username, role);
+    public AdminUserDto(String userId, String firstName, String lastName, String email, String username, UserRole role, Long companyId) {
+        super(userId, firstName, lastName, email, username, role);
         this.companyId = companyId;
     }
 }

--- a/common/src/main/java/com/rrsgroup/common/dto/SuperUserDto.java
+++ b/common/src/main/java/com/rrsgroup/common/dto/SuperUserDto.java
@@ -7,7 +7,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class SuperUserDto extends UserDto {
-    public SuperUserDto(String firstName, String lastName, String email, String username, UserRole role) {
-        super(firstName, lastName, email, username, role);
+    public SuperUserDto(String userId, String firstName, String lastName, String email, String username, UserRole role) {
+        super(userId, firstName, lastName, email, username, role);
     }
 }

--- a/common/src/main/java/com/rrsgroup/common/dto/UserDto.java
+++ b/common/src/main/java/com/rrsgroup/common/dto/UserDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public abstract class UserDto {
+    protected String userId;
     protected String firstName;
     protected String lastName;
     protected String email;

--- a/common/src/main/java/com/rrsgroup/common/security/JwtAuthenticationPrincipalConverter.java
+++ b/common/src/main/java/com/rrsgroup/common/security/JwtAuthenticationPrincipalConverter.java
@@ -29,6 +29,7 @@ public class JwtAuthenticationPrincipalConverter implements Converter<Jwt, Abstr
         UserDto user;
         if(userRole.get() == UserRole.SUPERUSER) {
             user = new SuperUserDto(
+                    jwtWrapper.getUserId(),
                     jwtWrapper.getFirstName(),
                     jwtWrapper.getLastName(),
                     jwtWrapper.getEmail(),
@@ -37,6 +38,7 @@ public class JwtAuthenticationPrincipalConverter implements Converter<Jwt, Abstr
         } else if(userRole.get() == UserRole.ADMIN) {
             if(jwtWrapper.getCompanyId().isEmpty()) throw new IllegalStateException("Admin user is not configured with a company");
             user = new AdminUserDto(
+                    jwtWrapper.getUserId(),
                     jwtWrapper.getFirstName(),
                     jwtWrapper.getLastName(),
                     jwtWrapper.getEmail(),

--- a/common/src/main/java/com/rrsgroup/common/util/JwtWrapper.java
+++ b/common/src/main/java/com/rrsgroup/common/util/JwtWrapper.java
@@ -18,6 +18,10 @@ public class JwtWrapper {
         this.jwt = jwt;
     }
 
+    public String getUserId() {
+        return getStringClaim(JwtClaimKey.USER_ID);
+    }
+
     public String getFirstName() {
         return getStringClaim(JwtClaimKey.FIRST_NAME);
     }

--- a/common/src/main/resources/db/migration/V1.11__update_lead_flow_column_names.sql
+++ b/common/src/main/resources/db/migration/V1.11__update_lead_flow_column_names.sql
@@ -1,0 +1,8 @@
+ALTER TABLE company.lead_flow
+RENAME COLUMN confirmation_message_1 TO confirmation_message1;
+
+ALTER TABLE company.lead_flow
+RENAME COLUMN confirmation_message_2 TO confirmation_message2;
+
+ALTER TABLE company.lead_flow
+RENAME COLUMN confirmation_message_3 TO confirmation_message3;

--- a/common/src/main/resources/db/migration/V1.12__move_status_from_lead_flow_to_order.sql
+++ b/common/src/main/resources/db/migration/V1.12__move_status_from_lead_flow_to_order.sql
@@ -1,0 +1,12 @@
+ALTER TABLE company.lead_flow
+DROP COLUMN status;
+
+ALTER TABLE company.lead_flow_order
+ADD COLUMN status VARCHAR(512) NOT NULL;
+
+ALTER TABLE company.lead_flow_order
+DROP CONSTRAINT lead_flow_order_company_id_ordinal_key;
+
+ALTER TABLE company.lead_flow_order
+ADD CONSTRAINT uq_lead_flow_order_company_id_ordinal_key_status
+UNIQUE(company_id, ordinal, status);

--- a/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlow.java
+++ b/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlow.java
@@ -3,6 +3,7 @@ package com.rrsgroup.company.entity;
 import com.rrsgroup.company.domain.Status;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,8 +24,7 @@ public class LeadFlow {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long id;
-    @NotBlank
-    @Size(max = 512)
+    @NotNull
     private Status status;
     @NotBlank
     @Size(max = 512)
@@ -47,9 +47,9 @@ public class LeadFlow {
     private String confirmationMessage2;
     @Size(max = 128)
     private String confirmationMessage3;
-    @NotBlank
+    @NotNull
     private LocalDateTime createdDate;
-    @NotBlank
+    @NotNull
     private LocalDateTime updatedDate;
     @NotBlank
     private String createdBy;

--- a/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlow.java
+++ b/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlow.java
@@ -24,8 +24,6 @@ public class LeadFlow {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long id;
-    @NotNull
-    private Status status;
     @NotBlank
     @Size(max = 512)
     private String name;

--- a/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlowOrder.java
+++ b/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlowOrder.java
@@ -3,6 +3,7 @@ package com.rrsgroup.company.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,20 +22,20 @@ public class LeadFlowOrder {
     @Id
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "company_id", referencedColumnName = "id", unique = true)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "company_id", referencedColumnName = "id")
     private Company company;
 
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "lead_flow_id", referencedColumnName = "id", unique = true)
     private LeadFlow leadFlow;
 
-    @NotBlank
+    @NotNull
     @Min(0)
     private Integer ordinal;
-    @NotBlank
+    @NotNull
     private LocalDateTime createdDate;
-    @NotBlank
+    @NotNull
     private LocalDateTime updatedDate;
     @NotBlank
     private String createdBy;

--- a/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlowOrder.java
+++ b/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlowOrder.java
@@ -1,5 +1,6 @@
 package com.rrsgroup.company.entity;
 
+import com.rrsgroup.company.domain.Status;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -33,6 +34,8 @@ public class LeadFlowOrder {
     @NotNull
     @Min(0)
     private Integer ordinal;
+    @NotNull
+    private Status status;
     @NotNull
     private LocalDateTime createdDate;
     @NotNull

--- a/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlowQuestion.java
+++ b/company-service/src/main/java/com/rrsgroup/company/entity/LeadFlowQuestion.java
@@ -3,6 +3,7 @@ package com.rrsgroup.company.entity;
 import com.rrsgroup.company.domain.LeadFlowQuestionDataType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,19 +23,18 @@ public class LeadFlowQuestion {
     @Id
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "lead_flow_id", referencedColumnName = "id", unique = true)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "lead_flow_id", referencedColumnName = "id")
     private LeadFlow leadFlow;
 
     @NotBlank
     @Size(max = 512)
     private String question;
-    @NotBlank
-    @Size(max = 512)
+    @NotNull
     private LeadFlowQuestionDataType dataType;
-    @NotBlank
+    @NotNull
     private LocalDateTime createdDate;
-    @NotBlank
+    @NotNull
     private LocalDateTime updatedDate;
     @NotBlank
     private String createdBy;

--- a/company-service/src/main/java/com/rrsgroup/company/repository/LeadFlowRepository.java
+++ b/company-service/src/main/java/com/rrsgroup/company/repository/LeadFlowRepository.java
@@ -1,0 +1,7 @@
+package com.rrsgroup.company.repository;
+
+import com.rrsgroup.company.entity.LeadFlow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LeadFlowRepository extends JpaRepository<LeadFlow, Long> {
+}

--- a/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowDtoMapper.java
+++ b/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowDtoMapper.java
@@ -7,6 +7,8 @@ import com.rrsgroup.company.entity.LeadFlowOrder;
 import com.rrsgroup.company.entity.LeadFlowQuestion;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class LeadFlowDtoMapper {
     public LeadFlowDto map(LeadFlow leadFlow) {
@@ -27,14 +29,27 @@ public class LeadFlowDtoMapper {
         return LeadFlowQuestion.builder().id(dto.id()).question(dto.question()).dataType(dto.dataType()).build();
     }
 
+    public LeadFlowQuestion map(LeadFlowQuestionDto dto, LeadFlow leadFlow) {
+        LeadFlowQuestion leadFlowQuestion = map(dto);
+        leadFlowQuestion.setLeadFlow(leadFlow);
+
+        return leadFlowQuestion;
+    }
+
     public LeadFlow map(LeadFlowDto dto) {
-        return LeadFlow.builder().id(dto.id()).status(dto.status()).name(dto.name()).icon(dto.iconUrl())
+        LeadFlow leadFlow = LeadFlow.builder().id(dto.id()).status(dto.status()).name(dto.name()).icon(dto.iconUrl())
                 .buttonText(dto.buttonText()).title(dto.title())
                 .confirmationMessageHeader(dto.confirmationMessageHeader())
                 .confirmationMessage1(dto.confirmationMessage1())
                 .confirmationMessage2(dto.confirmationMessage2())
-                .confirmationMessage3(dto.confirmationMessage3())
-                .leadFlowOrder(LeadFlowOrder.builder().ordinal(dto.ordinal()).build())
-                .questions(dto.questions().stream().map(this::map).toList()).build();
+                .confirmationMessage3(dto.confirmationMessage3()).build();
+
+        LeadFlowOrder leadFlowOrder = LeadFlowOrder.builder().ordinal(dto.ordinal()).leadFlow(leadFlow).build();
+        leadFlow.setLeadFlowOrder(leadFlowOrder);
+
+        List<LeadFlowQuestion> leadFlowQuestionList = dto.questions().stream().map(questionDto -> map(questionDto, leadFlow)).toList();
+        leadFlow.setQuestions(leadFlowQuestionList);
+
+        return leadFlow;
     }
 }

--- a/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowDtoMapper.java
+++ b/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowDtoMapper.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class LeadFlowDtoMapper {
     public LeadFlowDto map(LeadFlow leadFlow) {
         return new LeadFlowDto(leadFlow.getId(), leadFlow.getLeadFlowOrder().getCompany().getId(),
-                leadFlow.getStatus(), leadFlow.getName(), leadFlow.getIcon(), leadFlow.getButtonText(),
+                leadFlow.getLeadFlowOrder().getStatus(), leadFlow.getName(), leadFlow.getIcon(), leadFlow.getButtonText(),
                 leadFlow.getTitle(), leadFlow.getConfirmationMessageHeader(), leadFlow.getConfirmationMessage1(),
                 leadFlow.getConfirmationMessage2(), leadFlow.getConfirmationMessage3(),
                 leadFlow.getLeadFlowOrder().getOrdinal(),
@@ -37,14 +37,14 @@ public class LeadFlowDtoMapper {
     }
 
     public LeadFlow map(LeadFlowDto dto) {
-        LeadFlow leadFlow = LeadFlow.builder().id(dto.id()).status(dto.status()).name(dto.name()).icon(dto.iconUrl())
+        LeadFlow leadFlow = LeadFlow.builder().id(dto.id()).name(dto.name()).icon(dto.iconUrl())
                 .buttonText(dto.buttonText()).title(dto.title())
                 .confirmationMessageHeader(dto.confirmationMessageHeader())
                 .confirmationMessage1(dto.confirmationMessage1())
                 .confirmationMessage2(dto.confirmationMessage2())
                 .confirmationMessage3(dto.confirmationMessage3()).build();
 
-        LeadFlowOrder leadFlowOrder = LeadFlowOrder.builder().ordinal(dto.ordinal()).leadFlow(leadFlow).build();
+        LeadFlowOrder leadFlowOrder = LeadFlowOrder.builder().ordinal(dto.ordinal()).status(dto.status()).leadFlow(leadFlow).build();
         leadFlow.setLeadFlowOrder(leadFlowOrder);
 
         List<LeadFlowQuestion> leadFlowQuestionList = dto.questions().stream().map(questionDto -> map(questionDto, leadFlow)).toList();

--- a/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowService.java
+++ b/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowService.java
@@ -1,0 +1,59 @@
+package com.rrsgroup.company.service;
+
+import com.rrsgroup.common.dto.UserDto;
+import com.rrsgroup.company.entity.Company;
+import com.rrsgroup.company.entity.LeadFlow;
+import com.rrsgroup.company.repository.LeadFlowRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class LeadFlowService {
+    private final LeadFlowRepository leadFlowRepository;
+    private final CompanyService companyService;
+
+    @Autowired
+    public LeadFlowService(LeadFlowRepository leadFlowRepository, CompanyService companyService) {
+        this.leadFlowRepository = leadFlowRepository;
+        this.companyService = companyService;
+    }
+
+    public LeadFlow createLeadFlow(LeadFlow leadFlow, Long companyId, UserDto createdBy) {
+        LocalDateTime now = LocalDateTime.now();
+        String userId = createdBy.getUserId();
+
+        leadFlow.setCreatedBy(userId);
+        leadFlow.setCreatedDate(now);
+        leadFlow.setUpdatedBy(userId);
+        leadFlow.setUpdatedDate(now);
+
+        leadFlow.getLeadFlowOrder().setCreatedBy(userId);
+        leadFlow.getLeadFlowOrder().setCreatedDate(now);
+        leadFlow.getLeadFlowOrder().setUpdatedBy(userId);
+        leadFlow.getLeadFlowOrder().setUpdatedDate(now);
+        leadFlow.getLeadFlowOrder().setCompany(getCompany(companyId));
+
+        leadFlow.getQuestions().forEach(question -> {
+            question.setCreatedBy(userId);
+            question.setCreatedDate(now);
+            question.setUpdatedBy(userId);
+            question.setUpdatedDate(now);
+        });
+
+        return leadFlowRepository.save(leadFlow);
+    }
+
+    private Company getCompany(Long companyId) {
+        Optional<Company> companyOptional = companyService.getCompany(companyId);
+
+        if(companyOptional.isEmpty()) {
+            throw new IllegalStateException("The company does not exist for companyId=" + companyId);
+        }
+
+        return companyOptional.get();
+    }
+
+}

--- a/company-service/src/main/java/com/rrsgroup/company/web/LeadFlowController.java
+++ b/company-service/src/main/java/com/rrsgroup/company/web/LeadFlowController.java
@@ -1,0 +1,42 @@
+package com.rrsgroup.company.web;
+
+import com.rrsgroup.common.dto.AdminUserDto;
+import com.rrsgroup.company.dto.LeadFlowDto;
+import com.rrsgroup.company.entity.LeadFlow;
+import com.rrsgroup.company.service.LeadFlowDtoMapper;
+import com.rrsgroup.company.service.LeadFlowService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+public class LeadFlowController {
+    private final LeadFlowDtoMapper leadFlowDtoMapper;
+    private final LeadFlowService leadFlowService;
+
+    @Autowired
+    public LeadFlowController(LeadFlowDtoMapper leadFlowDtoMapper, LeadFlowService leadFlowService) {
+        this.leadFlowDtoMapper = leadFlowDtoMapper;
+        this.leadFlowService = leadFlowService;
+    }
+
+    @PostMapping("/api/admin/flows")
+    public LeadFlowDto addLeadFlow(@AuthenticationPrincipal AdminUserDto user, @RequestBody LeadFlowDto request) {
+        Long companyId = user.getCompanyId();
+
+        if(request.id() != null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The 'id' field shall not be populated in a add lead flow request");
+        }
+
+        if(request.companyId() != null && !request.companyId().equals(companyId)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "The companyId in the request body is not the user's company");
+        }
+
+        LeadFlow leadFlow = leadFlowDtoMapper.map(request);
+        return leadFlowDtoMapper.map(leadFlowService.createLeadFlow(leadFlow, companyId, user));
+    }
+}

--- a/company-service/src/test/groovy/com/rrsgroup/company/service/CompanyDtoMapperSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/service/CompanyDtoMapperSpec.groovy
@@ -3,7 +3,7 @@ package com.rrsgroup.company.service
 import com.rrsgroup.common.domain.SortDirection
 import com.rrsgroup.common.dto.AddressDto
 import com.rrsgroup.common.dto.PhoneNumberDto
-import CommonDtoMapperSpec
+import com.rrsgroup.common.service.CommonDtoMapper
 import com.rrsgroup.company.dto.CompanyDto
 import com.rrsgroup.company.entity.Company
 import com.rrsgroup.company.util.CompanyMockGenerator
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Sort
 import spock.lang.Specification
 
 class CompanyDtoMapperSpec extends Specification {
-    def commonDtoMapper = new CommonDtoMapperSpec()
+    def commonDtoMapper = new CommonDtoMapper()
     def mapper = new CompanyDtoMapper(commonDtoMapper)
     def companyMockGenerator = new CompanyMockGenerator()
 

--- a/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowDtoMapperSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowDtoMapperSpec.groovy
@@ -40,9 +40,9 @@ class LeadFlowDtoMapperSpec extends Specification {
         questions.add(LeadFlowQuestion.builder().id(question1Id).question(question1).dataType(question1DataType).build())
         questions.add(LeadFlowQuestion.builder().id(question2Id).question(question2).dataType(question2DataType).build())
 
-        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).company(company).build();
+        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).status(status).company(company).build();
 
-        def leadFlow = LeadFlow.builder().id(id).status(status).name(name).icon(iconUrl)
+        def leadFlow = LeadFlow.builder().id(id).name(name).icon(iconUrl)
                 .buttonText(buttonText).title(title).confirmationMessageHeader(confirmationMessageHeader)
                 .confirmationMessage1(confirmationMessage1).confirmationMessage2(confirmationMessage2)
                 .confirmationMessage3(confirmationMessage3).leadFlowOrder(leadFlowOrder).questions(questions).build()
@@ -104,7 +104,6 @@ class LeadFlowDtoMapperSpec extends Specification {
 
         then:
         result.getId() == id
-        result.getStatus() == status
         result.getName() == name
         result.getIcon() == iconUrl
         result.getButtonText() == buttonText
@@ -115,6 +114,7 @@ class LeadFlowDtoMapperSpec extends Specification {
         result.getConfirmationMessage3() == confirmationMessage3
         result.getLeadFlowOrder().getOrdinal() == ordinal
         result.getLeadFlowOrder().getLeadFlow() == result
+        result.getLeadFlowOrder().getStatus() == status
         result.getQuestions().get(0).getId() == question1Id
         result.getQuestions().get(0).getQuestion() == question1
         result.getQuestions().get(0).getDataType() == question1DataType

--- a/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowDtoMapperSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowDtoMapperSpec.groovy
@@ -1,0 +1,127 @@
+package com.rrsgroup.company.service
+
+import com.rrsgroup.company.domain.LeadFlowQuestionDataType
+import com.rrsgroup.company.domain.Status
+import com.rrsgroup.company.dto.LeadFlowDto
+import com.rrsgroup.company.dto.LeadFlowQuestionDto
+import com.rrsgroup.company.entity.Company
+import com.rrsgroup.company.entity.LeadFlow
+import com.rrsgroup.company.entity.LeadFlowOrder
+import com.rrsgroup.company.entity.LeadFlowQuestion
+import spock.lang.Specification
+
+class LeadFlowDtoMapperSpec extends Specification {
+    def leadFlowDtoMapper = new LeadFlowDtoMapper()
+
+    def "can map from LeadFlow to LeadFlowDto"() {
+        given:
+        def id = 1L
+        def companyId = 2L
+        def company = Mock(Company)
+        company.getId() >> companyId
+        def status = Status.INACTIVE
+        def name = "name"
+        def iconUrl = "test.jpg"
+        def buttonText = "Schedule"
+        def title = "Book Test"
+        def confirmationMessageHeader = "confirmationMessageHeader"
+        def confirmationMessage1 = "confirmationMessage1"
+        def confirmationMessage2 = "confirmationMessage2"
+        def confirmationMessage3 = "confirmationMessage3"
+        def ordinal = 0
+        def question1Id = 3L
+        def question1 = "question1"
+        def question1DataType = LeadFlowQuestionDataType.BOOLEAN
+        def question2Id = 4L
+        def question2 = "question2"
+        def question2DataType = LeadFlowQuestionDataType.TEXT
+
+        List<LeadFlowQuestion> questions = new ArrayList<>()
+        questions.add(LeadFlowQuestion.builder().id(question1Id).question(question1).dataType(question1DataType).build())
+        questions.add(LeadFlowQuestion.builder().id(question2Id).question(question2).dataType(question2DataType).build())
+
+        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).company(company).build();
+
+        def leadFlow = LeadFlow.builder().id(id).status(status).name(name).icon(iconUrl)
+                .buttonText(buttonText).title(title).confirmationMessageHeader(confirmationMessageHeader)
+                .confirmationMessage1(confirmationMessage1).confirmationMessage2(confirmationMessage2)
+                .confirmationMessage3(confirmationMessage3).leadFlowOrder(leadFlowOrder).questions(questions).build()
+
+        when:
+        def result = leadFlowDtoMapper.map(leadFlow)
+
+        then:
+        result.id() == id
+        result.companyId() == companyId
+        result.status() == status
+        result.name() == name
+        result.iconUrl() == iconUrl
+        result.buttonText() == buttonText
+        result.title() == title
+        result.confirmationMessageHeader() == confirmationMessageHeader
+        result.confirmationMessage1() == confirmationMessage1
+        result.confirmationMessage2() == confirmationMessage2
+        result.confirmationMessage3() == confirmationMessage3
+        result.ordinal() == ordinal
+        result.questions().get(0).id() == question1Id
+        result.questions().get(0).question() == question1
+        result.questions().get(0).dataType() == question1DataType
+        result.questions().get(1).id() == question2Id
+        result.questions().get(1).question() == question2
+        result.questions().get(1).dataType() == question2DataType
+    }
+
+    def "can map from LeadFlowDto to LeadFlow"() {
+        given:
+        def id = 1L
+        def companyId = 2L
+        def status = Status.INACTIVE
+        def name = "name"
+        def iconUrl = "test.jpg"
+        def buttonText = "Schedule"
+        def title = "Book Test"
+        def confirmationMessageHeader = "confirmationMessageHeader"
+        def confirmationMessage1 = "confirmationMessage1"
+        def confirmationMessage2 = "confirmationMessage2"
+        def confirmationMessage3 = "confirmationMessage3"
+        def ordinal = 0
+        def question1Id = 3L
+        def question1 = "question1"
+        def question1DataType = LeadFlowQuestionDataType.BOOLEAN
+        def question2Id = 4L
+        def question2 = "question2"
+        def question2DataType = LeadFlowQuestionDataType.TEXT
+
+        List<LeadFlowQuestionDto> questionDtos = new ArrayList<>()
+        questionDtos.add(new LeadFlowQuestionDto(question1Id, question1, question1DataType))
+        questionDtos.add(new LeadFlowQuestionDto(question2Id, question2, question2DataType))
+
+        def dto = new LeadFlowDto(id, companyId, status, name, iconUrl, buttonText, title, confirmationMessageHeader,
+                confirmationMessage1, confirmationMessage2, confirmationMessage3, ordinal, questionDtos)
+
+        when:
+        def result = leadFlowDtoMapper.map(dto)
+
+        then:
+        result.getId() == id
+        result.getStatus() == status
+        result.getName() == name
+        result.getIcon() == iconUrl
+        result.getButtonText() == buttonText
+        result.getTitle() == title
+        result.getConfirmationMessageHeader() == confirmationMessageHeader
+        result.getConfirmationMessage1() == confirmationMessage1
+        result.getConfirmationMessage2() == confirmationMessage2
+        result.getConfirmationMessage3() == confirmationMessage3
+        result.getLeadFlowOrder().getOrdinal() == ordinal
+        result.getLeadFlowOrder().getLeadFlow() == result
+        result.getQuestions().get(0).getId() == question1Id
+        result.getQuestions().get(0).getQuestion() == question1
+        result.getQuestions().get(0).getDataType() == question1DataType
+        result.getQuestions().get(0).getLeadFlow() == result
+        result.getQuestions().get(1).getId() == question2Id
+        result.getQuestions().get(1).getQuestion() == question2
+        result.getQuestions().get(1).getDataType() == question2DataType
+        result.getQuestions().get(1).getLeadFlow() == result
+    }
+}

--- a/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowServiceSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowServiceSpec.groovy
@@ -1,0 +1,111 @@
+package com.rrsgroup.company.service
+
+import com.rrsgroup.common.dto.UserDto
+import com.rrsgroup.company.domain.LeadFlowQuestionDataType
+import com.rrsgroup.company.domain.Status
+import com.rrsgroup.company.entity.Company
+import com.rrsgroup.company.entity.LeadFlow
+import com.rrsgroup.company.entity.LeadFlowOrder
+import com.rrsgroup.company.entity.LeadFlowQuestion
+import com.rrsgroup.company.repository.LeadFlowRepository
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+
+class LeadFlowServiceSpec extends Specification {
+    def leadFlowRepository = Mock(LeadFlowRepository)
+    def companyService = Mock(CompanyService)
+
+    def leadFlowService = new LeadFlowService(leadFlowRepository, companyService)
+
+    def "getCompany returns company if the company exists by company ID"() {
+        given:
+        def company = Mock(Company)
+        def companyId = 1L
+
+        when:
+        def result = leadFlowService.getCompany(companyId)
+
+        then:
+        1 * companyService.getCompany(companyId) >> Optional.of(company)
+        0 * _
+        result != null
+    }
+
+    def "getCompany throws IllegalStateException if company does not exist by company ID"() {
+        given:
+        def companyId = 1L
+
+        when:
+        leadFlowService.getCompany(companyId)
+
+        then:
+        1 * companyService.getCompany(companyId) >> Optional.empty()
+        0 * _
+        thrown(IllegalStateException)
+    }
+
+    def "createLeadFlow populates audit fields before saving"() {
+        given:
+        LocalDateTime startOfTest = LocalDateTime.now()
+        def id = 1L
+        def companyId = 2L
+        def company = Mock(Company)
+        company.getId() >> companyId
+        def status = Status.INACTIVE
+        def name = "name"
+        def iconUrl = "test.jpg"
+        def buttonText = "Schedule"
+        def title = "Book Test"
+        def confirmationMessageHeader = "confirmationMessageHeader"
+        def confirmationMessage1 = "confirmationMessage1"
+        def confirmationMessage2 = "confirmationMessage2"
+        def confirmationMessage3 = "confirmationMessage3"
+        def ordinal = 0
+        def question1Id = 3L
+        def question1 = "question1"
+        def question1DataType = LeadFlowQuestionDataType.BOOLEAN
+        def question2Id = 4L
+        def question2 = "question2"
+        def question2DataType = LeadFlowQuestionDataType.TEXT
+
+        List<LeadFlowQuestion> questions = new ArrayList<>()
+        questions.add(LeadFlowQuestion.builder().id(question1Id).question(question1).dataType(question1DataType).build())
+        questions.add(LeadFlowQuestion.builder().id(question2Id).question(question2).dataType(question2DataType).build())
+
+        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).company(company).build();
+
+        def leadFlow = LeadFlow.builder().id(id).status(status).name(name).icon(iconUrl)
+                .buttonText(buttonText).title(title).confirmationMessageHeader(confirmationMessageHeader)
+                .confirmationMessage1(confirmationMessage1).confirmationMessage2(confirmationMessage2)
+                .confirmationMessage3(confirmationMessage3).leadFlowOrder(leadFlowOrder).questions(questions).build()
+
+        def userId = "abcd"
+        def user = Mock(UserDto)
+        user.getUserId() >> userId
+
+        when:
+        def result = leadFlowService.createLeadFlow(leadFlow, companyId, user)
+
+        then:
+        1 * companyService.getCompany(companyId) >> Optional.of(company)
+        1 * leadFlowRepository.save(leadFlow) >> leadFlow
+        0 * _
+        result.getCreatedBy() == userId
+        result.getUpdatedBy() == userId
+        result.getCreatedDate().isAfter(startOfTest)
+        result.getUpdatedDate().isAfter(startOfTest)
+        result.getLeadFlowOrder().getCreatedBy() == userId
+        result.getLeadFlowOrder().getUpdatedBy() == userId
+        result.getLeadFlowOrder().getCreatedDate().isAfter(startOfTest)
+        result.getLeadFlowOrder().getUpdatedDate().isAfter(startOfTest)
+        result.getQuestions().get(0).getCreatedBy() == userId
+        result.getQuestions().get(0).getUpdatedBy() == userId
+        result.getQuestions().get(0).getCreatedDate().isAfter(startOfTest)
+        result.getQuestions().get(0).getUpdatedDate().isAfter(startOfTest)
+        result.getQuestions().get(1).getCreatedBy() == userId
+        result.getQuestions().get(1).getUpdatedBy() == userId
+        result.getQuestions().get(1).getCreatedDate().isAfter(startOfTest)
+        result.getQuestions().get(1).getUpdatedDate().isAfter(startOfTest)
+    }
+}

--- a/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowServiceSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowServiceSpec.groovy
@@ -73,16 +73,15 @@ class LeadFlowServiceSpec extends Specification {
         questions.add(LeadFlowQuestion.builder().id(question1Id).question(question1).dataType(question1DataType).build())
         questions.add(LeadFlowQuestion.builder().id(question2Id).question(question2).dataType(question2DataType).build())
 
-        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).company(company).build();
+        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).status(status).company(company).build();
 
-        def leadFlow = LeadFlow.builder().id(id).status(status).name(name).icon(iconUrl)
+        def leadFlow = LeadFlow.builder().id(id).name(name).icon(iconUrl)
                 .buttonText(buttonText).title(title).confirmationMessageHeader(confirmationMessageHeader)
                 .confirmationMessage1(confirmationMessage1).confirmationMessage2(confirmationMessage2)
                 .confirmationMessage3(confirmationMessage3).leadFlowOrder(leadFlowOrder).questions(questions).build()
 
         def userId = "abcd"
         def user = Mock(UserDto)
-        user.getUserId() >> userId
 
         when:
         def result = leadFlowService.createLeadFlow(leadFlow, companyId, user)
@@ -90,6 +89,7 @@ class LeadFlowServiceSpec extends Specification {
         then:
         1 * companyService.getCompany(companyId) >> Optional.of(company)
         1 * leadFlowRepository.save(leadFlow) >> leadFlow
+        1 * user.getUserId() >> userId
         0 * _
         result.getCreatedBy() == userId
         result.getUpdatedBy() == userId

--- a/company-service/src/test/groovy/com/rrsgroup/company/util/LeadFlowMockGenerator.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/util/LeadFlowMockGenerator.groovy
@@ -63,9 +63,9 @@ class LeadFlowMockGenerator extends Specification {
         questions.add(LeadFlowQuestion.builder().id(question1Id).question(question1).dataType(question1DataType).build())
         questions.add(LeadFlowQuestion.builder().id(question2Id).question(question2).dataType(question2DataType).build())
 
-        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).company(company).build();
+        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).status(status).company(company).build();
 
-        def leadFlow = LeadFlow.builder().id(id).status(status).name(name).icon(iconUrl)
+        def leadFlow = LeadFlow.builder().id(id).name(name).icon(iconUrl)
                 .buttonText(buttonText).title(title).confirmationMessageHeader(confirmationMessageHeader)
                 .confirmationMessage1(confirmationMessage1).confirmationMessage2(confirmationMessage2)
                 .confirmationMessage3(confirmationMessage3).leadFlowOrder(leadFlowOrder).questions(questions).build()

--- a/company-service/src/test/groovy/com/rrsgroup/company/util/LeadFlowMockGenerator.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/util/LeadFlowMockGenerator.groovy
@@ -1,0 +1,75 @@
+package com.rrsgroup.company.util
+
+import com.rrsgroup.company.domain.LeadFlowQuestionDataType
+import com.rrsgroup.company.domain.Status
+import com.rrsgroup.company.dto.LeadFlowDto
+import com.rrsgroup.company.dto.LeadFlowQuestionDto
+import com.rrsgroup.company.entity.Company
+import com.rrsgroup.company.entity.LeadFlow
+import com.rrsgroup.company.entity.LeadFlowOrder
+import com.rrsgroup.company.entity.LeadFlowQuestion
+import spock.lang.Specification
+
+class LeadFlowMockGenerator extends Specification {
+    LeadFlowDto getLeadFlowDtoMock(Long id, Long companyId) {
+        def status = Status.INACTIVE
+        def name = "name"
+        def iconUrl = "test.jpg"
+        def buttonText = "Schedule"
+        def title = "Book Test"
+        def confirmationMessageHeader = "confirmationMessageHeader"
+        def confirmationMessage1 = "confirmationMessage1"
+        def confirmationMessage2 = "confirmationMessage2"
+        def confirmationMessage3 = "confirmationMessage3"
+        def ordinal = 0
+        def question1Id = 3L
+        def question1 = "question1"
+        def question1DataType = LeadFlowQuestionDataType.BOOLEAN
+        def question2Id = 4L
+        def question2 = "question2"
+        def question2DataType = LeadFlowQuestionDataType.TEXT
+
+        List<LeadFlowQuestionDto> questionDtos = new ArrayList<>()
+        questionDtos.add(new LeadFlowQuestionDto(question1Id, question1, question1DataType))
+        questionDtos.add(new LeadFlowQuestionDto(question2Id, question2, question2DataType))
+
+        def dto = new LeadFlowDto(id, companyId, status, name, iconUrl, buttonText, title, confirmationMessageHeader,
+                confirmationMessage1, confirmationMessage2, confirmationMessage3, ordinal, questionDtos)
+
+        return dto
+    }
+
+    LeadFlow getLeadFlowMock(Long id, Long companyId) {
+        def company = Mock(Company)
+        company.getId() >> companyId
+        def status = Status.INACTIVE
+        def name = "name"
+        def iconUrl = "test.jpg"
+        def buttonText = "Schedule"
+        def title = "Book Test"
+        def confirmationMessageHeader = "confirmationMessageHeader"
+        def confirmationMessage1 = "confirmationMessage1"
+        def confirmationMessage2 = "confirmationMessage2"
+        def confirmationMessage3 = "confirmationMessage3"
+        def ordinal = 0
+        def question1Id = 3L
+        def question1 = "question1"
+        def question1DataType = LeadFlowQuestionDataType.BOOLEAN
+        def question2Id = 4L
+        def question2 = "question2"
+        def question2DataType = LeadFlowQuestionDataType.TEXT
+
+        List<LeadFlowQuestion> questions = new ArrayList<>()
+        questions.add(LeadFlowQuestion.builder().id(question1Id).question(question1).dataType(question1DataType).build())
+        questions.add(LeadFlowQuestion.builder().id(question2Id).question(question2).dataType(question2DataType).build())
+
+        def leadFlowOrder = LeadFlowOrder.builder().ordinal(ordinal).company(company).build();
+
+        def leadFlow = LeadFlow.builder().id(id).status(status).name(name).icon(iconUrl)
+                .buttonText(buttonText).title(title).confirmationMessageHeader(confirmationMessageHeader)
+                .confirmationMessage1(confirmationMessage1).confirmationMessage2(confirmationMessage2)
+                .confirmationMessage3(confirmationMessage3).leadFlowOrder(leadFlowOrder).questions(questions).build()
+
+        return leadFlow
+    }
+}

--- a/company-service/src/test/groovy/com/rrsgroup/company/web/CompanyControllerSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/web/CompanyControllerSpec.groovy
@@ -5,7 +5,7 @@ import com.rrsgroup.common.domain.UserRole
 import com.rrsgroup.common.dto.AddressDto
 import com.rrsgroup.common.dto.AdminUserDto
 import com.rrsgroup.common.dto.PhoneNumberDto
-import CommonDtoMapperSpec
+import com.rrsgroup.common.service.CommonDtoMapper
 import com.rrsgroup.company.dto.CompanyDto
 import com.rrsgroup.company.entity.Company
 import com.rrsgroup.company.service.CompanyDtoMapper
@@ -21,7 +21,7 @@ import spock.lang.Specification
 
 class CompanyControllerSpec extends Specification {
     def companyService = Mock(CompanyService)
-    def commonDtoMapper = new CommonDtoMapperSpec()
+    def commonDtoMapper = new CommonDtoMapper()
     def mapper = new CompanyDtoMapper(commonDtoMapper)
     def companyMockGenerator = new CompanyMockGenerator()
     def commonMockGenerator = new CommonMockGenerator()

--- a/company-service/src/test/groovy/com/rrsgroup/company/web/LeadFlowControllerSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/web/LeadFlowControllerSpec.groovy
@@ -1,7 +1,6 @@
 package com.rrsgroup.company.web
 
 import com.rrsgroup.common.dto.AdminUserDto
-import com.rrsgroup.common.dto.UserDto
 import com.rrsgroup.company.service.LeadFlowDtoMapper
 import com.rrsgroup.company.service.LeadFlowService
 import com.rrsgroup.company.util.LeadFlowMockGenerator

--- a/company-service/src/test/groovy/com/rrsgroup/company/web/LeadFlowControllerSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/web/LeadFlowControllerSpec.groovy
@@ -1,0 +1,83 @@
+package com.rrsgroup.company.web
+
+import com.rrsgroup.common.dto.AdminUserDto
+import com.rrsgroup.common.dto.UserDto
+import com.rrsgroup.company.service.LeadFlowDtoMapper
+import com.rrsgroup.company.service.LeadFlowService
+import com.rrsgroup.company.util.LeadFlowMockGenerator
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import spock.lang.Specification
+
+class LeadFlowControllerSpec extends Specification {
+    def leadFlowMockGenerator = new LeadFlowMockGenerator()
+    def leadFlowDtoMapper = new LeadFlowDtoMapper()
+    def leadFlowService = Mock(LeadFlowService)
+    def leadFlowController = new LeadFlowController(leadFlowDtoMapper, leadFlowService)
+
+    def "addLeadFlow throws a BAD REQUEST exception for requests that contain IDs"() {
+        given:
+        def leadFlowDto = leadFlowMockGenerator.getLeadFlowDtoMock(1L, 2L)
+        def userId = "abcd"
+        def user = Mock(AdminUserDto)
+        user.getUserId() >> userId
+
+        when:
+        leadFlowController.addLeadFlow(user, leadFlowDto)
+
+        then:
+        def e = thrown(ResponseStatusException.class)
+        e.getStatusCode() == HttpStatus.BAD_REQUEST
+    }
+
+    def "addLeadFlow throws a CONFLICT exception for requests that contain company ID, but does not match user's company"() {
+        given:
+        def leadFlowDto = leadFlowMockGenerator.getLeadFlowDtoMock(null, 2L)
+        def userId = "abcd"
+        def companyId = 1L
+        def user = Mock(AdminUserDto)
+        user.getUserId() >> userId
+        user.getCompanyId() >> companyId
+
+        when:
+        leadFlowController.addLeadFlow(user, leadFlowDto)
+
+        then:
+        def e = thrown(ResponseStatusException.class)
+        e.getStatusCode() == HttpStatus.CONFLICT
+    }
+
+    def "addLeadFlow creates lead if request does not contain companyId"() {
+        given:
+        def leadFlowDto = leadFlowMockGenerator.getLeadFlowDtoMock(null, null)
+        def userId = "abcd"
+        def companyId = 1L
+        def user = Mock(AdminUserDto)
+        user.getUserId() >> userId
+
+        when:
+        leadFlowController.addLeadFlow(user, leadFlowDto)
+
+        then:
+        1 * leadFlowService.createLeadFlow(_, companyId, user) >> leadFlowMockGenerator.getLeadFlowMock(1L, companyId)
+        1 * user.getCompanyId() >> companyId
+        0 * _
+    }
+
+    def "addLeadFlow creates lead if request contains companyId that matches user's company Id"() {
+        given:
+        def companyId = 1L
+        def leadFlowDto = leadFlowMockGenerator.getLeadFlowDtoMock(null, companyId)
+        def userId = "abcd"
+        def user = Mock(AdminUserDto)
+        user.getUserId() >> userId
+
+        when:
+        leadFlowController.addLeadFlow(user, leadFlowDto)
+
+        then:
+        1 * leadFlowService.createLeadFlow(_, companyId, user) >> leadFlowMockGenerator.getLeadFlowMock(1L, companyId)
+        1 * user.getCompanyId() >> companyId
+        0 * _
+    }
+}


### PR DESCRIPTION
This PR adds an endpoint `/api/admin/flows`. Example cURL:
```
curl --location 'localhost:8082/api/admin/flows' \
--header 'Content-Type: application/json' \
--header 'Authorization: ••••••' \
--data '{
    "companyId": 1,
    "status": "INACTIVE",
    "name": "Test Lead Flow",
    "iconUrl": "test.jpg",
    "buttonText": "Schedule",
    "title": "Book Test",
    "confirmationMessageHeader": "Booked!",
    "confirmationMessage1": "We'\''re on our way!",
    "ordinal": 1,
    "questions": [
        {
            "question": "Question 1",
            "dataType": "BOOLEAN"
        },
        {
            "question": "Question 2",
            "dataType": "TEXT"
        }
    ]
}'
```

Example response:
```
{
    "id": 8,
    "companyId": 1,
    "status": "INACTIVE",
    "name": "Test Lead Flow",
    "iconUrl": "test.jpg",
    "buttonText": "Schedule",
    "title": "Book Test",
    "confirmationMessageHeader": "Booked!",
    "confirmationMessage1": "We're on our way!",
    "confirmationMessage2": null,
    "confirmationMessage3": null,
    "ordinal": 1,
    "questions": [
        {
            "id": 3,
            "question": "Question 1",
            "dataType": "BOOLEAN"
        },
        {
            "id": 4,
            "question": "Question 2",
            "dataType": "TEXT"
        }
    ]
}
```