### PR TITLE
38: Add endpoint to retrieve lead

### DIFF
--- a/common/src/main/java/com/rrsgroup/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/rrsgroup/common/exception/GlobalExceptionHandler.java
@@ -37,9 +37,33 @@ public class GlobalExceptionHandler {
         }
     }
 
+    @ExceptionHandler(IllegalRequestException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalRequestException(IllegalRequestException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                ex.getMessage(),
+                request.getMethod() + " " + request.getRequestURI());
+        return ResponseEntity.status(status).body(response);
+    }
+
     @ExceptionHandler(IllegalUpdateException.class)
     public ResponseEntity<ErrorResponse> handleIllegalUpdateException(IllegalUpdateException ex, HttpServletRequest request) {
         HttpStatus status = HttpStatus.CONFLICT;
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                ex.getMessage(),
+                request.getMethod() + " " + request.getRequestURI());
+        return ResponseEntity.status(status).body(response);
+    }
+
+    @ExceptionHandler(RecordNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleRecordNotFoundException(RecordNotFoundException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.NOT_FOUND;
         ErrorResponse response = new ErrorResponse(
                 LocalDateTime.now(),
                 status.value(),

--- a/common/src/main/java/com/rrsgroup/common/exception/IllegalRequestException.java
+++ b/common/src/main/java/com/rrsgroup/common/exception/IllegalRequestException.java
@@ -1,0 +1,7 @@
+package com.rrsgroup.common.exception;
+
+public class IllegalRequestException extends RuntimeException {
+    public IllegalRequestException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/rrsgroup/common/exception/RecordNotFoundException.java
+++ b/common/src/main/java/com/rrsgroup/common/exception/RecordNotFoundException.java
@@ -1,0 +1,7 @@
+package com.rrsgroup.common.exception;
+
+public class RecordNotFoundException extends RuntimeException {
+    public RecordNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/common/src/test/groovy/com/rrsgroup/common/exception/GlobalExceptionHandlerSpec.groovy
+++ b/common/src/test/groovy/com/rrsgroup/common/exception/GlobalExceptionHandlerSpec.groovy
@@ -75,4 +75,42 @@ class GlobalExceptionHandlerSpec extends Specification {
         response.body.message == "Illegal update attempted"
         response.body.path == "PUT /api/resource/1"
     }
+
+    def "handleIllegalRequestException returns BAD_REQUEST with exception message"() {
+        given:
+        def ex = new IllegalRequestException("Illegal request attempted")
+        def request = Mock(HttpServletRequest) {
+            getMethod() >> "PUT"
+            getRequestURI() >> "/api/resource/1"
+        }
+
+        when:
+        ResponseEntity<ErrorResponse> response = handler.handleIllegalRequestException(ex, request)
+
+        then:
+        response.statusCode == HttpStatus.BAD_REQUEST
+        response.body.status == HttpStatus.BAD_REQUEST.value()
+        response.body.error == HttpStatus.BAD_REQUEST.reasonPhrase
+        response.body.message == "Illegal request attempted"
+        response.body.path == "PUT /api/resource/1"
+    }
+
+    def "handleRecordNotFoundException returns NOT_FOUND with exception message"() {
+        given:
+        def ex = new RecordNotFoundException("Record not found")
+        def request = Mock(HttpServletRequest) {
+            getMethod() >> "GET"
+            getRequestURI() >> "/api/resource/1"
+        }
+
+        when:
+        ResponseEntity<ErrorResponse> response = handler.handleRecordNotFoundException(ex, request)
+
+        then:
+        response.statusCode == HttpStatus.NOT_FOUND
+        response.body.status == HttpStatus.NOT_FOUND.value()
+        response.body.error == HttpStatus.NOT_FOUND.reasonPhrase
+        response.body.message == "Record not found"
+        response.body.path == "GET /api/resource/1"
+    }
 }

--- a/company-service/src/main/java/com/rrsgroup/company/repository/LeadFlowRepository.java
+++ b/company-service/src/main/java/com/rrsgroup/company/repository/LeadFlowRepository.java
@@ -16,4 +16,7 @@ public interface LeadFlowRepository extends JpaRepository<LeadFlow, Long> {
 
     @Query("SELECT lf FROM LeadFlow lf JOIN lf.leadFlowOrder lfo JOIN lfo.company c WHERE c.id = :companyId AND lfo.status IN (:statuses)")
     Page<LeadFlow> findByCompanyIdAndStatusIn(@Param("companyId") Long companyId, @Param("statuses") Collection<Status> statuses, Pageable pageable);
+
+    @Query("SELECT lf FROM LeadFlow lf JOIN lf.leadFlowOrder lfo JOIN lfo.company c WHERE c.id = :companyId AND lf.id = :id")
+    LeadFlow findByIdAndCompanyId(@Param("id") Long id, @Param("companyId") Long companyId);
 }

--- a/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowService.java
+++ b/company-service/src/main/java/com/rrsgroup/company/service/LeadFlowService.java
@@ -107,4 +107,8 @@ public class LeadFlowService {
             return sortField;
         }
     }
+
+    public LeadFlow getLeadFlow(Long leadFlowId, Long companyId) {
+        return leadFlowRepository.findByIdAndCompanyId(leadFlowId, companyId);
+    }
 }

--- a/company-service/src/main/java/com/rrsgroup/company/web/LeadFlowController.java
+++ b/company-service/src/main/java/com/rrsgroup/company/web/LeadFlowController.java
@@ -2,6 +2,9 @@ package com.rrsgroup.company.web;
 
 import com.rrsgroup.common.domain.SortDirection;
 import com.rrsgroup.common.dto.AdminUserDto;
+import com.rrsgroup.common.exception.IllegalRequestException;
+import com.rrsgroup.common.exception.IllegalUpdateException;
+import com.rrsgroup.common.exception.RecordNotFoundException;
 import com.rrsgroup.company.domain.Status;
 import com.rrsgroup.company.dto.LeadFlowDto;
 import com.rrsgroup.company.dto.LeadFlowListDto;
@@ -33,11 +36,11 @@ public class LeadFlowController {
         Long companyId = user.getCompanyId();
 
         if(request.id() != null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The 'id' field shall not be populated in a add lead flow request");
+            throw new IllegalRequestException("The 'id' field shall not be populated in a add lead flow request");
         }
 
         if(request.companyId() != null && !request.companyId().equals(companyId)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "The companyId in the request body is not the user's company");
+            throw new IllegalUpdateException("The companyId in the request body is not the user's company");
         }
 
         LeadFlow leadFlow = leadFlowDtoMapper.map(request);
@@ -56,5 +59,17 @@ public class LeadFlowController {
         Page<LeadFlow> pageOfLeadFlows = leadFlowService.getCompanyListOfLeadFlows(companyId, statuses, limit, page, sortField, sortDir);
 
         return leadFlowDtoMapper.map(pageOfLeadFlows);
+    }
+
+    @GetMapping("/api/admin/flows/{leadFlowId}")
+    public LeadFlowDto getLeadFlow(@AuthenticationPrincipal AdminUserDto user, @PathVariable(name = "leadFlowId") Long leadFlowId) {
+        Long companyId = user.getCompanyId();
+        LeadFlow leadFlow = leadFlowService.getLeadFlow(leadFlowId, companyId);
+
+        if(leadFlow == null) {
+            throw new RecordNotFoundException("The leadFlowId=" + leadFlowId + " was not found");
+        }
+
+        return leadFlowDtoMapper.map(leadFlow);
     }
 }

--- a/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowServiceSpec.groovy
+++ b/company-service/src/test/groovy/com/rrsgroup/company/service/LeadFlowServiceSpec.groovy
@@ -152,4 +152,20 @@ class LeadFlowServiceSpec extends Specification {
         leadFlowRepository.save(leadFlow) >> {throw new DataIntegrityViolationException("some_other_constraint")}
         thrown(DataIntegrityViolationException.class)
     }
+
+    def "getLeadFlow invokes repository to get lead flow by ID and companyId"() {
+        given:
+        def companyId = 2L
+        def leadFlowId = 3L
+        def leadFlow = Mock(LeadFlow) {
+            getId() >> { -> leadFlowId}
+        }
+
+        when:
+        def result = leadFlowService.getLeadFlow(leadFlowId, companyId)
+
+        then:
+        1 * leadFlowRepository.findByIdAndCompanyId(leadFlowId, companyId) >> leadFlow
+        result.getId() == leadFlowId
+    }
 }


### PR DESCRIPTION
Adds endpoint `GET /api/admin/flows/{leadFlowId}` which returns the following for records that exist:
```
{
    "id": 20,
    "companyId": 1,
    "status": "ACTIVE",
    "name": "Test Lead Flow",
    "iconUrl": "test.jpg",
    "buttonText": "Schedule",
    "title": "Book Test",
    "confirmationMessageHeader": "Booked!",
    "confirmationMessage1": "We're on our way!",
    "confirmationMessage2": null,
    "confirmationMessage3": null,
    "ordinal": 1,
    "questions": [
        {
            "id": 11,
            "question": "Question 1",
            "dataType": "BOOLEAN",
            "isRequired": true
        },
        {
            "id": 12,
            "question": "Question 2",
            "dataType": "TEXT",
            "isRequired": false
        }
    ],
    "predecessorId": null
}
```
and a 404 response body for records that do not exist for the request:
```
{
    "timestamp": "2025-09-17T23:16:18.432887",
    "status": 404,
    "error": "Not Found",
    "message": "The leadFlowId=22 was not found",
    "path": "GET /api/admin/flows/22"
}
```